### PR TITLE
fix: correct Trust Wallet deeplink format

### DIFF
--- a/packages/adapters/trust/src/utils.ts
+++ b/packages/adapters/trust/src/utils.ts
@@ -12,7 +12,7 @@ export const isTrustApp = function () {
 };
 export function openTrustWallet() {
     if (!isTrustApp() && isInMobileBrowser()) {
-        window.location.href = 'https://link.trustwallet.com?source=' + encodeURIComponent(window.location.href);
+        window.location.href = 'https://link.trustwallet.com/open_url?url=' + encodeURIComponent(window.location.href);
         return true;
     }
 


### PR DESCRIPTION
The previous deeplink schema was incorrect. According to the latest Trust Wallet documentation, the correct format is: https://link.trustwallet.com/open_url?url=xxx

FYI: 
https://developer.trustwallet.com/developer/develop-for-trust/deeplinking#dapp-browser