### PR TITLE
feat(ui): add openUrlWhenWalletNotFoundSync option to modal

### DIFF
--- a/packages/react/react-ui/src/Modal/WalletSelectModal.tsx
+++ b/packages/react/react-ui/src/Modal/WalletSelectModal.tsx
@@ -9,8 +9,13 @@ import { WalletItem } from '../WalletItem.js';
 type ModalProps = PropsWithChildren<{
     visible: boolean;
     onClose: () => void;
+    openUrlWhenWalletNotFoundSync?: boolean;
 }>;
-export const WalletSelectModal: FC<ModalProps> = function ({ visible, onClose }) {
+export const WalletSelectModal: FC<ModalProps> = function ({
+    visible,
+    onClose,
+    openUrlWhenWalletNotFoundSync = false,
+}) {
     const nodeRef = useRef(null);
     const { wallets, select } = useWallet();
     const [fadeIn, setFadeIn] = useState(false);
@@ -26,10 +31,16 @@ export const WalletSelectModal: FC<ModalProps> = function ({ visible, onClose })
 
     const onWalletClick = useCallback(
         (wallet: Wallet) => {
+            if (openUrlWhenWalletNotFoundSync && wallet.state === AdapterState.NotFound) {
+                if (wallet.adapter.url) {
+                    window.open(wallet.adapter.url, '_blank');
+                }
+                return;
+            }
             select(wallet.adapter.name);
             onClose();
         },
-        [select, onClose]
+        [select, onClose, openUrlWhenWalletNotFoundSync]
     );
     function show() {
         setRender(true);

--- a/packages/vue/vue-ui/src/Modal/WalletSelectModal.tsx
+++ b/packages/vue/vue-ui/src/Modal/WalletSelectModal.tsx
@@ -12,6 +12,10 @@ export const WalletSelectModal = defineComponent({
             type: Boolean,
             default: false,
         },
+        openUrlWhenWalletNotFoundSync: {
+            type: Boolean,
+            default: false,
+        },
     },
     emits: ['close'],
     setup(props, { emit }) {
@@ -45,6 +49,12 @@ export const WalletSelectModal = defineComponent({
         });
 
         const onWalletClick = (wallet: Wallet) => {
+            if (props.openUrlWhenWalletNotFoundSync && wallet.state === AdapterState.NotFound) {
+                if (wallet.adapter.url) {
+                    window.open(wallet.adapter.url, '_blank');
+                }
+                return;
+            }
             select(wallet.adapter.name);
             emit('close');
         };

--- a/packages/vue/vue-ui/src/WalletModalProvider.tsx
+++ b/packages/vue/vue-ui/src/WalletModalProvider.tsx
@@ -1,6 +1,12 @@
 import { defineComponent, provide, readonly, ref } from 'vue';
 import { WalletSelectModal } from './Modal/WalletSelectModal.js';
 export const WalletModalProvider = defineComponent({
+    props: {
+        openUrlWhenWalletNotFoundSync: {
+            type: Boolean,
+            default: false,
+        },
+    },
     setup(props, { slots }) {
         const visible = ref(false);
         function setVisible(v: boolean) {
@@ -13,7 +19,11 @@ export const WalletModalProvider = defineComponent({
         return () => (
             <>
                 {slots.default ? slots.default() : ''}
-                <WalletSelectModal visible={visible.value} onClose={() => setVisible(false)}></WalletSelectModal>
+                <WalletSelectModal
+                    visible={visible.value}
+                    onClose={() => setVisible(false)}
+                    openUrlWhenWalletNotFoundSync={props.openUrlWhenWalletNotFoundSync}
+                ></WalletSelectModal>
             </>
         );
     },


### PR DESCRIPTION
Problem:
The existing openUrlWhenWalletNotFound option in adapters does not work reliably because it executes asynchronously during the connect() call. Modern browsers block window.open() calls that are not triggered by direct user interaction (synchronous click handler), causing the wallet download URL to be blocked as a popup.

Solution:
Add a new openUrlWhenWalletNotFoundSync option to WalletModalProvider and WalletSelectModal components. When enabled, clicking on a NotFound wallet will immediately (synchronously) open the wallet's download URL in a new tab before any async operations, preventing browser blocking.

The modal stays open after opening the URL, allowing users to retry after installing the wallet.