### PR TITLE
fix: metamask ready state

### DIFF
--- a/packages/adapters/metamask-tron/package.json
+++ b/packages/adapters/metamask-tron/package.json
@@ -44,7 +44,7 @@
     },
     "dependencies": {
         "@tronweb3/tronwallet-abstract-adapter": "workspace:^",
-        "@metamask/multichain-api-client": "^0.10.1"
+        "@metamask/multichain-api-client": "0.11.0"
     },
     "devDependencies": {
         "@testing-library/dom": "^8.20.0",

--- a/packages/adapters/metamask-tron/src/adapter.ts
+++ b/packages/adapters/metamask-tron/src/adapter.ts
@@ -5,6 +5,7 @@ import {
     type Transport,
     getDefaultTransport,
     getMultichainClient,
+    isMetamaskInstalled,
 } from '@metamask/multichain-api-client';
 import type { TronAddress } from '@metamask/multichain-api-client/dist/types/scopes/tron.types.cjs';
 import {
@@ -36,7 +37,7 @@ export class MetaMaskAdapter extends Adapter {
         'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAiIGhlaWdodD0iMzAiIHZpZXdCb3g9IjAgMCAzMCAzMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjIzIiBoZWlnaHQ9IjIzIiB4PSIzLjUiIHk9IjMuNSIgdmlld0JveD0iMCAwIDE0MS41MSAxMzYuNDIiPjxwYXRoIGZpbGw9IiNGRjVDMTYiIGQ9Im0xMzIuMjQgMTMxLjc1LTMwLjQ4LTkuMDctMjIuOTkgMTMuNzQtMTYuMDMtLjAxLTIzLTEzLjc0LTMwLjQ3IDkuMDhMMCAxMDAuNDdsOS4yNy0zNC43M0wwIDM2LjQgOS4yNyAwbDQ3LjYgMjguNDRoMjcuNzZMMTMyLjI0IDBsOS4yNyAzNi4zOC05LjI3IDI5LjM2IDkuMjcgMzQuNzItOS4yNyAzMS4zWiIvPjxwYXRoIGZpbGw9IiNGRjVDMTYiIGQ9Im05LjI3IDAgNDcuNjEgMjguNDZMNTQuOTggNDggOS4yOSAwWm0zMC40NyAxMDAuNDggMjAuOTUgMTUuOTUtMjAuOTUgNi4yNHYtMjIuMlpNNTkuMDEgNzQuMSA1NSA0OCAyOS4yMiA2NS43NWgtLjAybC4wOCAxOC4yNyAxMC40NS05LjkyaDE5LjI5Wk0xMzIuMjUgMGwtNDcuNiAyOC40Nkw4Ni41MSA0OGw0NS43Mi00OFptLTMwLjQ3IDEwMC40OC0yMC45NCAxNS45NSAyMC45NCA2LjI0di0yMi4yWm0xMC41My0zNC43M0w4Ni41MyA0OCA4Mi41IDc0LjFoMTkuMjdsMTAuNDYgOS45LjA3LTE4LjI2WiIvPjxwYXRoIGZpbGw9IiNFMzQ4MDciIGQ9Im0zOS43MyAxMjIuNjctMzAuNDYgOS4wOEwwIDEwMC40OGgzOS43M3YyMi4yWk01OS4wMiA3NC4xbDUuODIgMzcuNzEtOC4wNy0yMC45Ny0yNy40OS02LjgyIDEwLjQ2LTkuOTJINTlabTQyLjc2IDQ4LjU5IDMwLjQ3IDkuMDcgOS4yNy0zMS4yN2gtMzkuNzR6TTgyLjUgNzQuMDlsLTUuODIgMzcuNzEgOC4wNi0yMC45NyAyNy41LTYuODItMTAuNDctOS45MnoiLz48cGF0aCBmaWxsPSIjRkY4RDVEIiBkPSJtMCAxMDAuNDcgOS4yNy0zNC43M0gyOS4ybC4wNyAxOC4yNyAyNy41IDYuODIgOC4wNiAyMC45Ny00LjE1IDQuNjItMjAuOTQtMTUuOTZIMFptMTQxLjUgMC05LjI2LTM0LjczaC0xOS45M2wtLjA3IDE4LjI3LTI3LjUgNi44Mi04LjA2IDIwLjk3IDQuMTUgNC42MiAyMC45NC0xNS45NmgzOS43NFpNODQuNjQgMjguNDRINTYuODhsLTEuODkgMTkuNTQgOS44NCA2My44aDExLjg1bDkuODUtNjMuOC0xLjktMTkuNTRaIi8+PHBhdGggZmlsbD0iIzY2MTgwMCIgZD0iTTkuMjcgMCAwIDM2LjM4bDkuMjcgMjkuMzZIMjkuMkw1NC45OCA0OHptNDMuOTggODEuNjdoLTkuMDNsLTQuOTIgNC44MSAxNy40NyA0LjMzLTMuNTItOS4xNVpNMTMyLjI0IDBsOS4yNyAzNi4zOC05LjI3IDI5LjM2aC0xOS45M0w4Ni41MyA0OHpNODguMjcgODEuNjdoOS4wNGw0LjkyIDQuODItMTcuNDkgNC4zNCAzLjUzLTkuMTdabS05LjUgNDIuMyAyLjA2LTcuNTQtNC4xNS00LjYySDY0LjgybC00LjE0IDQuNjIgMi4wNSA3LjU0Ii8+PHBhdGggZmlsbD0iI0MwQzRDRCIgZD0iTTc4Ljc3IDEyMy45N3YxMi40NUg2Mi43NHYtMTIuNDVoMTYuMDJaIi8+PHBhdGggZmlsbD0iI0U3RUJGNiIgZD0ibTM5Ljc0IDEyMi42NiAyMyAxMy43NnYtMTIuNDZsLTIuMDUtNy41NHptNjIuMDMgMC0yMyAxMy43NnYtMTIuNDZsMi4wNi03LjU0eiIvPjwvc3ZnPjwvc3ZnPg==';
     url = 'https://metamask.io';
 
-    private _readyState: WalletReadyState = WalletReadyState.Found;
+    private _readyState: WalletReadyState = WalletReadyState.Loading;
     private _state: AdapterState = AdapterState.Disconnect;
     private _connecting = false;
     private _switchingChain = false;
@@ -333,29 +334,19 @@ export class MetaMaskAdapter extends Adapter {
      * Checks if the MetaMask wallet is available in the browser.
      * By default, the _readyState is set to Found to avoid issues on page reloads.
      * But if the wallet is not actually available, we need to update the _readyState accordingly.
-     * Average time for transport to be connected is around 50-300ms.
-     * Will retry up to maxAttempts times with a 10ms delay between attempts.
+     * Average time for wallet to be available is around 50ms.
      * @returns A promise that resolves to true if the wallet is found.
      */
-    private async checkWallet(attempt = 1, maxAttempts = 100): Promise<boolean> {
-        const isConnected = this._transport.isConnected();
-
-        if (isConnected) {
+    private async checkWallet(): Promise<boolean> {
+        const metamaskInstalled = await isMetamaskInstalled();
+        if (metamaskInstalled) {
             this._readyState = WalletReadyState.Found;
             this.emit('readyStateChanged', this.readyState);
-
             return true;
         }
-
-        if (attempt >= maxAttempts) {
-            this._readyState = WalletReadyState.NotFound;
-            this.emit('readyStateChanged', this.readyState);
-
-            return false;
-        }
-
-        await new Promise((resolve) => setTimeout(resolve, this._transport.warmupTimeout ?? 100));
-        return this.checkWallet(attempt + 1, maxAttempts);
+        this._readyState = WalletReadyState.NotFound;
+        this.emit('readyStateChanged', this.readyState);
+        return false;
     }
 
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,7 +746,7 @@ importers:
         version: 8.20.1
       jest:
         specifier: '28'
-        version: 28.1.3(@types/node@18.19.42)(ts-node@10.9.2(@types/node@18.19.42)(typescript@5.5.4))
+        version: 28.1.3(@types/node@22.7.5)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.4))
       jest-environment-jsdom:
         specifier: '28'
         version: 28.1.3(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -765,7 +765,7 @@ importers:
         version: 8.20.1
       jest:
         specifier: '28'
-        version: 28.1.3(@types/node@22.7.5)(ts-node@10.9.2(@types/node@22.7.5)(typescript@5.5.4))
+        version: 28.1.3(@types/node@18.19.42)(ts-node@10.9.2(@types/node@18.19.42)(typescript@5.5.4))
       jest-environment-jsdom:
         specifier: '28'
         version: 28.1.3(bufferutil@4.0.8)(utf-8-validate@6.0.3)
@@ -886,8 +886,8 @@ importers:
   packages/adapters/metamask-tron:
     dependencies:
       '@metamask/multichain-api-client':
-        specifier: ^0.10.1
-        version: 0.10.1
+        specifier: 0.11.0
+        version: 0.11.0
       '@tronweb3/tronwallet-abstract-adapter':
         specifier: workspace:^
         version: link:../abstract-adapter
@@ -3073,8 +3073,8 @@ packages:
     resolution: {integrity: sha512-dwZPq8wx9yV3IX2caLi9q9xZBw2XeIoYqdyihDDDpuHVCEiqadJLwqM3zy+uwf6F1QYQ65A8aOMQg1Uw7LMLNg==}
     engines: {node: '>=16.0.0'}
 
-  '@metamask/multichain-api-client@0.10.1':
-    resolution: {integrity: sha512-LsqO2SiDcTgOuXyVYEB0zgBaVNhryhP2tYI3L7tLa7PoeDqMkNIreFhDeu8jM5tPWkCimQvMwCkG3DF4P5dD3A==}
+  '@metamask/multichain-api-client@0.11.0':
+    resolution: {integrity: sha512-htoO8TCMXLKl6gl4m8fB69f+pC4N6Q2hG9Zcchiypi39jasUUntDV7CTbZuzj39w7SRheR/sc6lZBA8FFb13Cg==}
     engines: {node: ^18.20 || ^20.17 || >=22}
 
   '@metamask/rpc-errors@6.3.1':
@@ -12258,7 +12258,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@metamask/multichain-api-client@0.10.1': {}
+  '@metamask/multichain-api-client@0.11.0': {}
 
   '@metamask/rpc-errors@6.3.1':
     dependencies:


### PR DESCRIPTION
# Description

This PR fixes a bug where MetaMask readyState stayed on the `Found` state even when the MetaMask was disabled or not installed.

It is done by using the isMetamaskInstalled function exposed by @metamask/multichain-api-client to check either if MetaMask extension is installed or if we're in the MetaMask mobile in-app browser.