### PR TITLE
docs: replace wallet table with summary in Supported Wallets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,9 @@ Decide based on your framework and the level of UI control you need:
 
 ## 🔌 Supported Wallets
 
-Each adapter offers a consistent interface. You can use this collective package or import individual ones.
+We support a wide range of TRON and EVM wallets, including TronLink, MetaMask, WalletConnect, Ledger, and [more](https://walletadapter.org/docs/guide/wallet-reference.html#supported-wallets-by-adapter). Each adapter offers a consistent interface — use the collective `@tronweb3/tronwallet-adapters` package and import individual adapters.
 
-| Wallet            | NPM Package                                                                                                          | Description                                             | Source                                                                                           |
-| :---------------- | :------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------------------------------------------------- |
-| **All-in-One**    | [`@tronweb3/tronwallet-adapters`](https://npmjs.com/package/@tronweb3/tronwallet-adapters)                           | Includes all adapters below                             | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/adapters)      |
-| **TronLink**      | [`@tronweb3/tronwallet-adapter-tronlink`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-tronlink)           | Adapter for [TronLink](https://www.tronlink.org/)       | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/tronlink)      |
-| **WalletConnect** | [`@tronweb3/tronwallet-adapter-walletconnect`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-walletconnect) | Adapter for [WalletConnect](https://walletconnect.com/) | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/walletconnect) |
-| **Ledger**        | [`@tronweb3/tronwallet-adapter-ledger`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-ledger)               | Hardware wallet support                                 | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/ledger)        |
-| **MetaMask EVM**  | [`@tronweb3/tronwallet-adapter-metamask-evm`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-metamask-evm)   | Native EVM support                                      | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/evm/metamask)  |
-
-> ℹ️ For the full list of supported wallets, visit our [documentation](https://walletadapter.org/docs/guide/wallet-reference.html#supported-wallets-by-adapter).
+👉 For the complete list of supported wallets and their adapters, visit our [documentation](https://walletadapter.org/docs/guide/wallet-reference.html#supported-wallets-by-adapter).
 
 > **Note**: In case wallet developers intend to release breaking changes, you can [open an issue here](https://github.com/tronweb3/tronwallet-adapter/issues/new) to inform us, thus enabling us to update the new protocols accordingly.
 

--- a/packages/adapters/adapters/README.md
+++ b/packages/adapters/adapters/README.md
@@ -21,18 +21,10 @@ npm install @tronweb3/tronwallet-abstract-adapter @tronweb3/tronwallet-adapter-w
 
 ## 🔌 Supported Wallets
 
-Each adapter offers a consistent interface. You can use this collective package or import individual ones.
+We support a wide range of TRON and EVM wallets, including TronLink, MetaMask, WalletConnect, Ledger, and [more](https://walletadapter.org/docs/guide/wallet-reference.html#supported-wallets-by-adapter). Each adapter offers a consistent interface — use the collective `@tronweb3/tronwallet-adapters` package and import individual adapters.
 
-| Wallet            | NPM Package                                                                                                          | Description                                             | Source                                                                                           |
-| :---------------- | :------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------ | :----------------------------------------------------------------------------------------------- |
-| **All-in-One**    | [`@tronweb3/tronwallet-adapters`](https://npmjs.com/package/@tronweb3/tronwallet-adapters)                           | Includes all adapters below                             | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/adapters)      |
-| **TronLink**      | [`@tronweb3/tronwallet-adapter-tronlink`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-tronlink)           | Adapter for [TronLink](https://www.tronlink.org/)       | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/tronlink)      |
-| **WalletConnect** | [`@tronweb3/tronwallet-adapter-walletconnect`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-walletconnect) | Adapter for [WalletConnect](https://walletconnect.com/) | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/walletconnect) |
-| **MetaMask**      | [`@tronweb3/tronwallet-adapter-metamask-tron`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-metamask-tron) | Tron support via [MetaMask](https://metamask.io/)       | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/metamask-tron) |
-| **Ledger**        | [`@tronweb3/tronwallet-adapter-ledger`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-ledger)               | Hardware wallet support                                 | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/ledger)        |
-| **MetaMask EVM**  | [`@tronweb3/tronwallet-adapter-metamask-evm`](https://npmjs.com/package/@tronweb3/tronwallet-adapter-metamask-evm)   | Native EVM support                                      | [View](https://github.com/tronweb3/tronwallet-adapter/tree/main/packages/adapters/evm/metamask)  |
+👉 For the complete list of supported wallets and their adapters, visit our [documentation](https://walletadapter.org/docs/guide/wallet-reference.html#supported-wallets-by-adapter).
 
-> ℹ️ For the full list of supported wallets, visit our [documentation](https://walletadapter.org/docs/guide/wallet-reference.html#supported-wallets-by-adapter).
 
 ---
 


### PR DESCRIPTION
Remove the limited wallet listing table from both root and adapters README, replace with a concise description that highlights breadth of support and links to the full documentation.